### PR TITLE
refactor(server): unify approval processing into single code path

### DIFF
--- a/dcaf/core/adapters/inbound/server_adapter.py
+++ b/dcaf/core/adapters/inbound/server_adapter.py
@@ -41,6 +41,7 @@ from ....schemas.messages import (
     ExecutedApproval,
     ExecutedCommand,
     ExecutedToolCall,
+    FileObject,
 )
 from ...agent import Agent
 
@@ -136,20 +137,14 @@ class ServerAdapter:
         request_fields: dict[str, Any] = messages.get("_request_fields", {})  # type: ignore[assignment]
         context = {**request_fields, **platform_context} if request_fields else platform_context
 
-        # Check for approved tool calls that need to be processed
-        executed_tool_calls = self._process_approved_tool_calls(messages_list, context)
-
-        # Process legacy command approvals
-        executed_commands = self._process_approved_commands(messages_list, context)
-
-        # Process unified approvals
-        executed_approvals = self._process_approvals(messages_list, context)
+        # Unified approval processing — normalize all sources, execute once
+        all_approvals = self._normalize_approvals(messages_list)
+        executed_approvals = self._process_approvals(all_approvals, context)
+        executed_commands, executed_tool_calls = self._fan_out_executed(executed_approvals)
 
         # Convert to Core format and inject execution results
         core_messages = self._convert_messages(messages_list)
-        self._inject_execution_results(
-            core_messages, executed_tool_calls, executed_commands, executed_approvals
-        )
+        self._inject_execution_results(core_messages, executed_approvals)
 
         if not core_messages:
             return AgentMessage(content="No messages provided.")
@@ -212,7 +207,18 @@ class ServerAdapter:
         # 3. Legacy: CommandsEvent only for command items
         command_items = [tc for tc in event.tool_calls if tc.approval_type == "command"]
         if command_items:
-            commands = [Command(command=tc.name) for tc in command_items]
+            commands = []
+            for tc in command_items:
+                raw_files = tc.input.get("files") or None
+                files: list[FileObject] | None = None
+                if raw_files:
+                    files = [FileObject(**f) for f in raw_files]
+                commands.append(
+                    Command(
+                        command=tc.input.get("command", tc.name),
+                        files=files,
+                    )
+                )
             results.append(CommandsEvent(commands=commands))
 
         return results
@@ -281,26 +287,22 @@ class ServerAdapter:
         request_fields: dict[str, Any] = messages.get("_request_fields", {})  # type: ignore[assignment]
         context = {**request_fields, **platform_context} if request_fields else platform_context
 
-        # Execute any approved tool calls before streaming
-        executed_tool_calls = self._process_approved_tool_calls(messages_list, context)
+        # Unified approval processing — normalize all sources, execute once
+        all_approvals = self._normalize_approvals(messages_list)
+        executed_approvals = self._process_approvals(all_approvals, context)
+        executed_commands, executed_tool_calls = self._fan_out_executed(executed_approvals)
+
+        # Emit execution events — unified first, then legacy
+        if executed_approvals:
+            yield ExecutedApprovalsEvent(executed_approvals=executed_approvals)
+        if executed_commands:
+            yield ExecutedCommandsEvent(executed_cmds=executed_commands)
         if executed_tool_calls:
             yield ExecutedToolCallsEvent(executed_tool_calls=executed_tool_calls)
 
-        # Process legacy command approvals
-        executed_commands = self._process_approved_commands(messages_list, context)
-        if executed_commands:
-            yield ExecutedCommandsEvent(executed_cmds=executed_commands)
-
-        # Process unified approvals
-        executed_approvals = self._process_approvals(messages_list, context)
-        if executed_approvals:
-            yield ExecutedApprovalsEvent(executed_approvals=executed_approvals)
-
         # Convert to Core format and inject execution results
         core_messages = self._convert_messages(messages_list)
-        self._inject_execution_results(
-            core_messages, executed_tool_calls, executed_commands, executed_approvals
-        )
+        self._inject_execution_results(core_messages, executed_approvals)
 
         if not core_messages:
             yield ErrorEvent(error="No messages provided")
@@ -322,26 +324,22 @@ class ServerAdapter:
     def _inject_execution_results(
         self,
         core_messages: list[dict[str, Any]],
-        executed_tool_calls: list[ExecutedToolCall],
-        executed_commands: list[ExecutedCommand],
         executed_approvals: list[ExecutedApproval],
     ) -> None:
-        """Inject tool/command/approval results into the conversation as a user message."""
+        """Inject execution results into the conversation as a user message.
+
+        Branches on approval type for the context string format:
+        - command: "Executed command: <cmd>\nOutput: <out>"
+        - tool_call: "Tool result for <name> with inputs <input>: <out>"
+        """
         parts: list[str] = []
-        if executed_tool_calls:
-            parts.extend(
-                f"Tool result for {tc.name} with inputs {tc.input}: {tc.output}"
-                for tc in executed_tool_calls
-            )
-        if executed_commands:
-            parts.extend(
-                f"Executed command: {ec.command}\nOutput: {ec.output}" for ec in executed_commands
-            )
-        if executed_approvals:
-            parts.extend(
-                f"Tool result for {ea.name} with inputs {ea.input}: {ea.output}"
-                for ea in executed_approvals
-            )
+        for ea in executed_approvals:
+            if ea.type == "command":
+                parts.append(
+                    f"Executed command: {ea.input.get('command', ea.name)}\nOutput: {ea.output}"
+                )
+            else:
+                parts.append(f"Tool result for {ea.name} with inputs {ea.input}: {ea.output}")
         if not parts:
             return
         result_content = "\n\n".join(parts)
@@ -399,55 +397,93 @@ class ServerAdapter:
                     return platform_context if isinstance(platform_context, dict) else {}
         return {}
 
-    def _process_approved_tool_calls(
+    def _normalize_approvals(
         self,
         messages_list: list[dict[str, Any]],
-        platform_context: dict[str, Any],
-    ) -> list[ExecutedToolCall]:
-        """
-        Process any approved tool calls from incoming messages.
+    ) -> list[dict[str, Any]]:
+        """Normalize all approval sources from the latest message into a single list.
 
-        When the user approves tool calls, they come back in the
-        message data. We execute them here and return results.
+        Reads data.approvals[], data.cmds[], and data.tool_calls[] and converts
+        all entries to the unified Approval dict format.  data.approvals[] entries
+        take precedence — legacy entries whose id already appears in approvals are
+        skipped to avoid double-execution.
         """
-        executed_tools: list[ExecutedToolCall] = []
-
         if not messages_list:
-            return executed_tools
+            return []
 
-        # Get the latest message's data
-        latest_message = messages_list[-1]
-        data = latest_message.get("data", {})
-        tool_calls = data.get("tool_calls", [])
+        data = messages_list[-1].get("data", {})
+        seen_ids: set[str] = set()
+        result: list[dict[str, Any]] = []
 
-        for tool_call in tool_calls:
-            tool_name = tool_call.get("name")
-            tool_input = tool_call.get("input", {})
-            tool_id = tool_call.get("id")
+        # 1. Unified approvals — source of truth
+        for a in data.get("approvals", []):
+            aid = a.get("id", "")
+            if aid:
+                seen_ids.add(aid)
+            result.append(a)
 
-            if tool_call.get("execute", False):
-                # User approved - execute the tool
-                result = self._execute_tool(tool_name, tool_input, platform_context)
-                executed_tools.append(
-                    ExecutedToolCall(
-                        id=tool_id,
-                        name=tool_name,
-                        input=tool_input,
-                        output=result,
+        # 2. Legacy data.cmds[] — normalize to command-type Approval
+        for cmd in data.get("cmds", []):
+            command_str = cmd.get("command", "")
+            result.append(
+                {
+                    "id": uuid.uuid4().hex,
+                    "type": "command",
+                    "name": command_str,
+                    "input": {"command": command_str, "files": cmd.get("files")},
+                    "execute": cmd.get("execute", False),
+                    "rejection_reason": cmd.get("rejection_reason"),
+                }
+            )
+
+        # 3. Legacy data.tool_calls[] — normalize to tool_call-type Approval
+        for tc in data.get("tool_calls", []):
+            tc_id = tc.get("id") or uuid.uuid4().hex
+            if tc_id in seen_ids:
+                continue  # already covered by data.approvals[]
+            result.append(
+                {
+                    "id": tc_id,
+                    "type": "tool_call",
+                    "name": tc.get("name", ""),
+                    "input": tc.get("input", {}),
+                    "execute": tc.get("execute", False),
+                    "rejection_reason": tc.get("rejection_reason"),
+                }
+            )
+
+        return result
+
+    def _fan_out_executed(
+        self,
+        executed_approvals: list[ExecutedApproval],
+    ) -> tuple[list[ExecutedCommand], list[ExecutedToolCall]]:
+        """Convert ExecutedApproval list to legacy ExecutedCommand / ExecutedToolCall lists.
+
+        These are used to populate the legacy fields in the response (data.executed_cmds,
+        data.executed_tool_calls) and the legacy stream events (ExecutedCommandsEvent,
+        ExecutedToolCallsEvent) for backward-compatible clients.
+        """
+        cmds: list[ExecutedCommand] = []
+        tool_calls: list[ExecutedToolCall] = []
+        for ea in executed_approvals:
+            if ea.type == "command":
+                cmds.append(
+                    ExecutedCommand(
+                        command=ea.input.get("command", ea.name),
+                        output=ea.output,
                     )
                 )
-            elif tool_call.get("rejection_reason"):
-                # User rejected
-                executed_tools.append(
+            else:
+                tool_calls.append(
                     ExecutedToolCall(
-                        id=tool_id,
-                        name=tool_name,
-                        input=tool_input,
-                        output=f"Tool rejected: {tool_call['rejection_reason']}",
+                        id=ea.id,
+                        name=ea.name,
+                        input=ea.input,
+                        output=ea.output,
                     )
                 )
-
-        return executed_tools
+        return cmds, tool_calls
 
     def _execute_tool(
         self,
@@ -528,62 +564,19 @@ class ServerAdapter:
             if work_dir:
                 shutil.rmtree(work_dir, ignore_errors=True)
 
-    def _process_approved_commands(
-        self,
-        messages_list: list[dict[str, Any]],
-        context: dict[str, Any] | None = None,
-    ) -> list[ExecutedCommand]:
-        """
-        Process approved/rejected commands from the legacy cmds field.
-
-        Reads data.cmds[] from the latest message. Approved commands are
-        executed via subprocess; rejected commands record the rejection reason.
-        """
-        executed: list[ExecutedCommand] = []
-
-        if not messages_list:
-            return executed
-
-        latest_message = messages_list[-1]
-        cmds = latest_message.get("data", {}).get("cmds", [])
-
-        for cmd in cmds:
-            command = cmd.get("command", "")
-            files = cmd.get("files") or None  # list[dict] | None
-            if cmd.get("execute", False):
-                logger.info("Executing approved command: %s", command)
-                output = self._execute_cmd(command, files=files, context=context)
-                executed.append(ExecutedCommand(command=command, output=output))
-            elif cmd.get("rejection_reason"):
-                executed.append(
-                    ExecutedCommand(
-                        command=command,
-                        output=f"Rejected: {cmd['rejection_reason']}",
-                    )
-                )
-
-        return executed
-
     def _process_approvals(
         self,
-        messages_list: list[dict[str, Any]],
+        approvals: list[dict[str, Any]],
         platform_context: dict[str, Any],
     ) -> list[ExecutedApproval]:
-        """
-        Process approved/rejected items from the unified approvals field.
+        """Execute a pre-normalized list of approval dicts.
 
-        Reads data.approvals[] from the latest message. For each:
-        - If execute=True: runs the tool via _execute_tool() and captures output
-        - If rejection_reason is set: captures the rejection as output
+        For each entry:
+        - type="command" + execute=True  → _execute_cmd()
+        - type="tool_call" + execute=True → _execute_tool()
+        - rejection_reason set            → record rejection (no execution)
         """
         executed: list[ExecutedApproval] = []
-
-        if not messages_list:
-            return executed
-
-        latest_message = messages_list[-1]
-        data = latest_message.get("data", {})
-        approvals = data.get("approvals", [])
 
         for approval in approvals:
             approval_id = approval.get("id", "")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -322,7 +322,7 @@ def get_weather(city: str, units: str = "celsius") -> str:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `description` | Docstring | What the tool does (shown to LLM) |
-| `requires_approval` | `False` | Whether to require human approval |
+| `requires_approval` | `True` | Whether to require human approval. **Always set this explicitly.** |
 | `schema` | Auto-generated | Dict schema OR Pydantic model class |
 
 ### Complete Tools Example

--- a/docs/guides/building-tools.md
+++ b/docs/guides/building-tools.md
@@ -55,8 +55,11 @@ from dcaf.tools import tool
 
 The simplest approach is to let DCAF auto-generate the schema from your function signature:
 
+!!! warning "Default: `requires_approval=True`"
+    The `@tool` decorator defaults to `requires_approval=True` (safe by default). Tools without an explicit `requires_approval=False` will pause and wait for human approval before executing — the agent will not auto-run them. **Always set `requires_approval` explicitly.**
+
 ```python
-@tool(description="Generate a personalized greeting for a user")
+@tool(description="Generate a personalized greeting for a user", requires_approval=False)
 def greet_user(name: str, language: str = "english") -> str:
     """Generate a personalized greeting."""
     greetings = {
@@ -96,7 +99,7 @@ DCAF supports three ways to define tool input schemas, giving you flexibility ba
 Let DCAF infer the schema from your function signature:
 
 ```python
-@tool(description="Create a new Kubernetes deployment")
+@tool(description="Create a new Kubernetes deployment", requires_approval=True)
 def create_deployment(
     name: str,
     image: str,
@@ -411,7 +414,8 @@ import requests
             "properties": {},
             "required": []
         }
-    }
+    },
+    requires_approval=False  # Read-only — no approval needed
 )
 def get_tenant_services(platform_context: dict) -> str:
     """Get services from DuploCloud API."""
@@ -666,7 +670,8 @@ executor = ThreadPoolExecutor(max_workers=4)
             },
             "required": ["operation_id"]
         }
-    }
+    },
+    requires_approval=True  # Set explicitly — this mutates state
 )
 def long_running_operation(operation_id: str) -> str:
     """Execute a long operation with timeout handling."""
@@ -702,7 +707,8 @@ from dcaf.tools import tool
             },
             "required": ["endpoint"]
         }
-    }
+    },
+    requires_approval=False  # Read-only GET — no approval needed
 )
 def api_call_with_retry(endpoint: str, max_retries: int = 3) -> str:
     """Make API call with exponential backoff retry."""
@@ -854,7 +860,7 @@ from dcaf.llm import BedrockLLM
 from dcaf.agents import ToolCallingAgent
 from dcaf.tools import tool
 
-@tool(schema={...})
+@tool(schema={...}, requires_approval=False)
 def my_tool(param: str) -> str:
     return f"Result: {param}"
 
@@ -909,7 +915,7 @@ def test_agent_uses_tool():
 ### 3. Validate Early, Fail Fast
 
 ```python
-@tool(schema={...})
+@tool(schema={...}, requires_approval=True)
 def create_resource(name: str, config: dict) -> str:
     # Validate immediately
     if not name:
@@ -936,7 +942,7 @@ return "Done"
 ### 5. Handle Errors Gracefully
 
 ```python
-@tool(schema={...})
+@tool(schema={...}, requires_approval=False)
 def api_call(endpoint: str) -> str:
     try:
         response = requests.get(endpoint)
@@ -952,17 +958,19 @@ def api_call(endpoint: str) -> str:
         return f"Error: Unexpected error - {str(e)}"
 ```
 
-### 6. Use Appropriate Approval Settings
+### 6. Always Set `requires_approval` Explicitly
+
+The default is `requires_approval=True` (safe by default). Omitting it means the tool will pause for human approval even if you didn't intend that. **Always set it explicitly** so the behavior is obvious to readers.
 
 ```python
-# Read operations - no approval needed
+# Read operations - set False explicitly
 @tool(schema={...}, requires_approval=False)
 def list_resources(): ...
 
 @tool(schema={...}, requires_approval=False)
 def get_status(): ...
 
-# Write operations - approval recommended
+# Write operations - set True explicitly (even though it's the default)
 @tool(schema={...}, requires_approval=True)
 def create_resource(): ...
 
@@ -978,7 +986,8 @@ def delete_resource(): ...
         "name": "tenant_specific_action",
         "description": "Perform action in current tenant. Requires tenant_name and duplo_token in platform context.",
         "input_schema": {...}
-    }
+    },
+    requires_approval=True  # Set explicitly based on whether this mutates state
 )
 def tenant_specific_action(data: str, platform_context: dict) -> str:
     """

--- a/examples/core_server.py
+++ b/examples/core_server.py
@@ -29,7 +29,7 @@ from dcaf.core import Agent, serve, tool  # noqa: E402
 
 
 # Define some example tools
-@tool(description="Get the current time")
+@tool(description="Get the current time", requires_approval=False)
 def get_time() -> str:
     """Get the current time."""
     from datetime import datetime
@@ -37,7 +37,7 @@ def get_time() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
-@tool(description="Echo back a message")
+@tool(description="Echo back a message", requires_approval=False)
 def echo(message: str) -> str:
     """Echo back the given message."""
     return f"You said: {message}"
@@ -53,14 +53,25 @@ def dangerous_operation(action: str) -> str:
     return f"Executed dangerous action: {action}"
 
 
+@tool(requires_approval=True, approval_type="command", description="Run a shell command")
+def run_shell_command(command: str) -> str:
+    """
+    Run a shell command — shown as a terminal/command approval in the UI.
+
+    This demonstrates the command approval_type pattern.
+    """
+    return f"Ran command: {command}"
+
+
 # Create the agent
 agent = Agent(
-    tools=[get_time, echo, dangerous_operation],
+    tools=[get_time, echo, dangerous_operation, run_shell_command],
     system_prompt="""You are a helpful assistant. You have access to the following tools:
 
 - get_time: Returns the current time
 - echo: Echoes back a message
-- dangerous_operation: Requires approval before execution
+- dangerous_operation: Perform a potentially risky action
+- run_shell_command: Run a shell command
 
 When the user asks you to do something, use the appropriate tool.
 """,

--- a/tests/core/test_cmd_flow.py
+++ b/tests/core/test_cmd_flow.py
@@ -1,0 +1,353 @@
+"""Tests for the full data.cmds[] / executed_cmds workflow.
+
+Covers:
+- CommandsEvent contains actual command string (not tool name)
+- CommandsEvent includes files from tool input
+- User-sent executed_cmds are injected into LLM context
+- Command rejection reason is recorded in ExecutedCommand
+- Multi-turn history executed_cmds all injected
+"""
+
+from unittest.mock import MagicMock
+
+from dcaf.core.adapters.inbound.server_adapter import ServerAdapter
+from dcaf.core.schemas.events import DoneEvent, ToolCallsEvent
+from dcaf.core.schemas.messages import ToolCall
+
+
+def _make_adapter(**kwargs):
+    mock_agent = MagicMock()
+    mock_agent.tools = []
+    return ServerAdapter(mock_agent, **kwargs)
+
+
+def _make_command_tool_call(
+    *,
+    id: str = "tc-1",
+    name: str = "run_shell_command",
+    command: str = "kubectl get pods",
+    files: list | None = None,
+    intent: str | None = None,
+) -> ToolCall:
+    input_data: dict = {"command": command}
+    if files is not None:
+        input_data["files"] = files
+    return ToolCall(
+        id=id,
+        name=name,
+        input=input_data,
+        tool_description="Run a shell command",
+        input_description={},
+        approval_type="command",
+        intent=intent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CommandsEvent data structure correctness
+# ---------------------------------------------------------------------------
+
+
+class TestCommandsEventContainsActualCommand:
+    def test_commands_event_command_field_is_actual_command_string(self):
+        """CommandsEvent.commands[].command must be the shell command, not the tool name."""
+        adapter = _make_adapter()
+        tool_call = _make_command_tool_call(
+            name="run_shell_command", command="kubectl get pods -n default"
+        )
+        event = ToolCallsEvent(tool_calls=[tool_call])
+
+        results = adapter._translate_tool_calls_event(event)
+        commands_events = [e for e in results if e.type == "commands"]
+
+        assert len(commands_events) == 1
+        cmd = commands_events[0].commands[0]
+        assert cmd.command == "kubectl get pods -n default", (
+            f"Expected actual command string, got '{cmd.command}' (tool name instead?)"
+        )
+
+    def test_commands_event_command_field_is_not_tool_name(self):
+        """Command.command must never equal the tool function name."""
+        adapter = _make_adapter()
+        tool_call = _make_command_tool_call(name="run_shell_command", command="ls -la /tmp")
+        event = ToolCallsEvent(tool_calls=[tool_call])
+
+        results = adapter._translate_tool_calls_event(event)
+        commands_events = [e for e in results if e.type == "commands"]
+
+        cmd = commands_events[0].commands[0]
+        assert cmd.command != "run_shell_command", (
+            "Command.command must be the shell command, not the Python tool name"
+        )
+
+    def test_commands_event_execute_defaults_to_false(self):
+        """CommandsEvent proposals must have execute=False (pending approval)."""
+        adapter = _make_adapter()
+        tool_call = _make_command_tool_call(command="helm list")
+        event = ToolCallsEvent(tool_calls=[tool_call])
+
+        results = adapter._translate_tool_calls_event(event)
+        commands_events = [e for e in results if e.type == "commands"]
+
+        cmd = commands_events[0].commands[0]
+        assert cmd.execute is False, "Proposed command must have execute=False"
+
+
+class TestCommandsEventIncludesFiles:
+    def test_files_from_tool_input_are_in_commands_event(self):
+        """CommandsEvent.commands[].files must include files from tool input."""
+        adapter = _make_adapter()
+        files = [{"file_path": "values.yaml", "file_content": "replicaCount: 3"}]
+        tool_call = _make_command_tool_call(command="helm upgrade myapp .", files=files)
+        event = ToolCallsEvent(tool_calls=[tool_call])
+
+        results = adapter._translate_tool_calls_event(event)
+        commands_events = [e for e in results if e.type == "commands"]
+
+        cmd = commands_events[0].commands[0]
+        assert cmd.files is not None, "Command must include files from tool input"
+        assert len(cmd.files) == 1
+        assert cmd.files[0].file_path == "values.yaml"
+        assert cmd.files[0].file_content == "replicaCount: 3"
+
+    def test_no_files_in_input_means_none_in_command(self):
+        """When tool input has no files, Command.files should be None."""
+        adapter = _make_adapter()
+        tool_call = _make_command_tool_call(command="ls -la")
+        event = ToolCallsEvent(tool_calls=[tool_call])
+
+        results = adapter._translate_tool_calls_event(event)
+        commands_events = [e for e in results if e.type == "commands"]
+
+        cmd = commands_events[0].commands[0]
+        assert cmd.files is None
+
+
+# ---------------------------------------------------------------------------
+# User-sent executed_cmds injected into LLM context
+# ---------------------------------------------------------------------------
+
+
+class TestUserExecutedCmdsInjectedIntoContext:
+    def test_user_executed_cmds_appended_to_message_content(self):
+        """data.executed_cmds from user turn must be injected into LLM message content."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "I ran my own commands, analyze them",
+                "data": {
+                    "executed_cmds": [
+                        {
+                            "command": "kubectl get pods",
+                            "output": "NAME   READY   STATUS\napp    1/1     Running",
+                        }
+                    ]
+                },
+            }
+        ]
+
+        core_messages = adapter._convert_messages(messages)
+
+        assert len(core_messages) == 1
+        content = core_messages[0]["content"]
+        assert "kubectl get pods" in content
+        assert "NAME   READY   STATUS" in content
+
+    def test_multiple_user_executed_cmds_all_injected(self):
+        """All executed_cmds entries must appear in LLM context."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "check these",
+                "data": {
+                    "executed_cmds": [
+                        {"command": "kubectl get pods", "output": "app Running"},
+                        {"command": "kubectl get services", "output": "svc ClusterIP"},
+                    ]
+                },
+            }
+        ]
+
+        core_messages = adapter._convert_messages(messages)
+        content = core_messages[0]["content"]
+
+        assert "kubectl get pods" in content
+        assert "app Running" in content
+        assert "kubectl get services" in content
+        assert "svc ClusterIP" in content
+
+    def test_user_executed_cmds_in_earlier_turn_also_injected(self):
+        """executed_cmds on an earlier user turn must be preserved in history."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "first turn",
+                "data": {
+                    "executed_cmds": [{"command": "kubectl get nodes", "output": "node1 Ready"}]
+                },
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": "second turn",
+                "data": {},
+            },
+        ]
+
+        core_messages = adapter._convert_messages(messages)
+
+        # First user message must include the executed cmd
+        assert "kubectl get nodes" in core_messages[0]["content"]
+        assert "node1 Ready" in core_messages[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Command rejection reason
+# ---------------------------------------------------------------------------
+
+
+class TestCommandRejectionReason:
+    def _process_cmds(self, adapter, messages, ctx=None):
+        """Helper: normalize + process approvals, fan out to ExecutedCommand list."""
+        normalized = adapter._normalize_approvals(messages)
+        executed_approvals = adapter._process_approvals(normalized, ctx or {})
+        cmds, _ = adapter._fan_out_executed(executed_approvals)
+        return cmds
+
+    def test_rejected_command_records_rejection_reason(self):
+        """Rejected command with rejection_reason must be recorded with that reason."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "",
+                "data": {
+                    "cmds": [
+                        {
+                            "command": "rm -rf /",
+                            "execute": False,
+                            "rejection_reason": "Too dangerous",
+                        }
+                    ]
+                },
+            }
+        ]
+
+        results = self._process_cmds(adapter, messages)
+
+        assert len(results) == 1
+        assert results[0].command == "rm -rf /"
+        assert "Too dangerous" in results[0].output
+
+    def test_approved_command_executes_and_not_rejected(self):
+        """Approved command must be executed, not treated as rejected."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "",
+                "data": {"cmds": [{"command": "echo hello", "execute": True}]},
+            }
+        ]
+
+        results = self._process_cmds(adapter, messages)
+
+        assert len(results) == 1
+        assert "hello" in results[0].output
+        assert "Rejected" not in results[0].output
+
+    def test_unapproved_command_without_reason_is_skipped(self):
+        """Command with execute=False and no rejection_reason must be ignored."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "content": "",
+                "data": {"cmds": [{"command": "ls", "execute": False}]},
+            }
+        ]
+
+        results = self._process_cmds(adapter, messages)
+
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# CommandsEvent emitted in invoke_stream for command-type tool calls
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_that_streams(*events):
+    mock_agent = MagicMock()
+    mock_agent.tools = []
+
+    async def fake_stream(*args, **kwargs):
+        for event in events:
+            yield event
+
+    mock_agent.run_stream = MagicMock(side_effect=fake_stream)
+    return mock_agent
+
+
+class TestCommandsEventEmittedInStream:
+    async def test_command_type_tool_call_emits_commands_event(self):
+        """invoke_stream must emit CommandsEvent for command-type tool calls."""
+        tool_call = _make_command_tool_call(command="kubectl get pods")
+        agent = _make_agent_that_streams(
+            ToolCallsEvent(tool_calls=[tool_call]),
+            DoneEvent(),
+        )
+        adapter = ServerAdapter(agent)
+
+        events = [
+            e
+            async for e in adapter.invoke_stream(
+                {"messages": [{"role": "user", "content": "check pods"}]}
+            )
+        ]
+
+        assert any(e.type == "commands" for e in events), "CommandsEvent must be emitted"
+
+    async def test_commands_event_has_correct_command_string(self):
+        """CommandsEvent in stream must contain actual shell command, not tool name."""
+        tool_call = _make_command_tool_call(
+            name="run_shell_command", command="kubectl get pods -n prod"
+        )
+        agent = _make_agent_that_streams(
+            ToolCallsEvent(tool_calls=[tool_call]),
+            DoneEvent(),
+        )
+        adapter = ServerAdapter(agent)
+
+        events = [
+            e
+            async for e in adapter.invoke_stream(
+                {"messages": [{"role": "user", "content": "check pods"}]}
+            )
+        ]
+
+        commands_events = [e for e in events if e.type == "commands"]
+        assert len(commands_events) == 1
+        assert commands_events[0].commands[0].command == "kubectl get pods -n prod"
+
+    async def test_approvals_event_also_emitted_for_command_type(self):
+        """ApprovalsEvent must also be emitted alongside CommandsEvent."""
+        tool_call = _make_command_tool_call(command="helm list")
+        agent = _make_agent_that_streams(
+            ToolCallsEvent(tool_calls=[tool_call]),
+            DoneEvent(),
+        )
+        adapter = ServerAdapter(agent)
+
+        events = [
+            e
+            async for e in adapter.invoke_stream(
+                {"messages": [{"role": "user", "content": "list charts"}]}
+            )
+        ]
+
+        assert any(e.type == "approvals" for e in events)
+        assert any(e.type == "commands" for e in events)

--- a/tests/core/test_server_adapter.py
+++ b/tests/core/test_server_adapter.py
@@ -18,7 +18,7 @@ def _make_adapter(**kwargs):
 
 class TestProcessApprovedCommandsReceivesContext:
     def test_context_is_passed_to_execute_cmd(self):
-        """_process_approved_commands must forward platform_context to _execute_cmd."""
+        """data.cmds[] commands must forward platform_context to _execute_cmd."""
         adapter = _make_adapter()
         ctx = {"tenant_name": "acme", "kubeconfig": "/home/user/.kube/config"}
 
@@ -30,7 +30,8 @@ class TestProcessApprovedCommandsReceivesContext:
                     "data": {"cmds": [{"command": "kubectl get pods", "execute": True}]},
                 }
             ]
-            adapter._process_approved_commands(messages, ctx)
+            normalized = adapter._normalize_approvals(messages)
+            adapter._process_approvals(normalized, ctx)
             mock_exec.assert_called_once_with("kubectl get pods", files=None, context=ctx)
 
     def test_empty_context_is_forwarded(self):
@@ -43,7 +44,8 @@ class TestProcessApprovedCommandsReceivesContext:
                     "data": {"cmds": [{"command": "ls", "execute": True}]},
                 }
             ]
-            adapter._process_approved_commands(messages, {})
+            normalized = adapter._normalize_approvals(messages)
+            adapter._process_approvals(normalized, {})
             mock_exec.assert_called_once_with("ls", files=None, context={})
 
 
@@ -69,7 +71,8 @@ class TestProcessApprovedCommandsPassesFiles:
                     },
                 }
             ]
-            adapter._process_approved_commands(messages, {})
+            normalized = adapter._normalize_approvals(messages)
+            adapter._process_approvals(normalized, {})
             mock_exec.assert_called_once_with("helm install myapp .", files=files, context={})
 
     def test_no_files_passes_none(self):
@@ -82,7 +85,8 @@ class TestProcessApprovedCommandsPassesFiles:
                     "data": {"cmds": [{"command": "ls", "execute": True}]},
                 }
             ]
-            adapter._process_approved_commands(messages, {})
+            normalized = adapter._normalize_approvals(messages)
+            adapter._process_approvals(normalized, {})
             mock_exec.assert_called_once_with("ls", files=None, context={})
 
 
@@ -185,8 +189,8 @@ class TestCustomExecutorCallback:
         result = adapter._execute_cmd("echo default", files=None, context={})
         assert "default" in result
 
-    def test_custom_executor_wires_through_process_approved_commands(self):
-        """Custom executor is called end-to-end from _process_approved_commands."""
+    def test_custom_executor_wires_through_unified_path(self):
+        """Custom executor is called end-to-end via the unified approval path."""
         calls: list[str] = []
 
         def my_executor(command, files, context):
@@ -201,9 +205,11 @@ class TestCustomExecutorCallback:
                 "data": {"cmds": [{"command": "kubectl get pods", "execute": True}]},
             }
         ]
-        results = adapter._process_approved_commands(messages, {})
+        normalized = adapter._normalize_approvals(messages)
+        executed_approvals = adapter._process_approvals(normalized, {})
+        cmds, _ = adapter._fan_out_executed(executed_approvals)
         assert calls == ["kubectl get pods"]
-        assert results[0].output == "custom result"
+        assert cmds[0].output == "custom result"
 
 
 def _make_agent_that_streams(*events):
@@ -335,6 +341,7 @@ class TestThreadIdFlowsThroughContext:
             }
         ]
         ctx = adapter._extract_platform_context(messages)
-        adapter._process_approved_commands(messages, ctx)
+        normalized = adapter._normalize_approvals(messages)
+        adapter._process_approvals(normalized, ctx)
 
         assert received[0].get("thread_id") == "thread-abc"

--- a/tests/core/test_unified_approvals.py
+++ b/tests/core/test_unified_approvals.py
@@ -261,7 +261,7 @@ class TestProcessApprovals:
             }
         ]
 
-        result = adapter._process_approvals(messages_list, {})
+        result = adapter._process_approvals(adapter._normalize_approvals(messages_list), {})
 
         assert len(result) == 1
         assert result[0].id == "ap-1"
@@ -293,7 +293,7 @@ class TestProcessApprovals:
             }
         ]
 
-        result = adapter._process_approvals(messages_list, {})
+        result = adapter._process_approvals(adapter._normalize_approvals(messages_list), {})
 
         assert len(result) == 1
         assert result[0].id == "ap-2"
@@ -351,7 +351,7 @@ class TestProcessApprovals:
             }
         ]
 
-        result = adapter._process_approvals(messages_list, {})
+        result = adapter._process_approvals(adapter._normalize_approvals(messages_list), {})
 
         assert len(result) == 2
         assert result[0].output == "pod1"
@@ -383,7 +383,7 @@ class TestProcessApprovals:
             }
         ]
 
-        result = adapter._process_approvals(messages_list, {})
+        result = adapter._process_approvals(adapter._normalize_approvals(messages_list), {})
 
         assert len(result) == 1
         assert result[0].type == "command"

--- a/tests/core/test_unified_processing.py
+++ b/tests/core/test_unified_processing.py
@@ -1,0 +1,533 @@
+"""Tests for the unified approval processing path in ServerAdapter.
+
+Covers:
+- _normalize_approvals: merges data.approvals[], data.cmds[], data.tool_calls[]
+- _fan_out_executed: converts ExecutedApproval list to legacy types
+- invoke/invoke_stream: single processing path end-to-end
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from dcaf.core.adapters.inbound.server_adapter import ServerAdapter
+from dcaf.core.schemas.events import DoneEvent, TextDeltaEvent
+from dcaf.core.schemas.messages import ExecutedApproval
+
+
+def _make_adapter(**kwargs):
+    mock_agent = MagicMock()
+    mock_agent.tools = []
+    return ServerAdapter(mock_agent, **kwargs)
+
+
+def _make_agent_with_tool(tool_name: str, tool_result: str):
+    mock_tool = MagicMock()
+    mock_tool.name = tool_name
+    mock_tool.execute = MagicMock(return_value=tool_result)
+    mock_agent = MagicMock()
+    mock_agent.tools = [mock_tool]
+    return mock_agent, mock_tool
+
+
+# ---------------------------------------------------------------------------
+# _normalize_approvals
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeApprovals:
+    def test_empty_messages_returns_empty(self):
+        adapter = _make_adapter()
+        assert adapter._normalize_approvals([]) == []
+
+    def test_no_data_field_returns_empty(self):
+        adapter = _make_adapter()
+        result = adapter._normalize_approvals([{"role": "user", "content": "hi"}])
+        assert result == []
+
+    def test_approvals_passed_through(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "approvals": [
+                        {
+                            "id": "a1",
+                            "type": "tool_call",
+                            "name": "foo",
+                            "input": {},
+                            "execute": True,
+                        }
+                    ]
+                },
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 1
+        assert result[0]["id"] == "a1"
+        assert result[0]["type"] == "tool_call"
+
+    def test_cmds_normalized_to_approval_with_command_type(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {"cmds": [{"command": "kubectl get pods", "execute": True}]},
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 1
+        assert result[0]["type"] == "command"
+        assert result[0]["input"]["command"] == "kubectl get pods"
+        assert result[0]["execute"] is True
+
+    def test_cmds_normalized_id_is_generated(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {"cmds": [{"command": "ls", "execute": True}]},
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert result[0]["id"]  # non-empty generated UUID
+
+    def test_cmds_files_included_in_normalized_input(self):
+        adapter = _make_adapter()
+        files = [{"file_path": "f.yaml", "file_content": "x: 1"}]
+        messages = [
+            {
+                "role": "user",
+                "data": {"cmds": [{"command": "helm install .", "execute": True, "files": files}]},
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert result[0]["input"]["files"] == files
+
+    def test_cmds_rejection_reason_preserved(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "cmds": [
+                        {"command": "rm -rf /", "execute": False, "rejection_reason": "Dangerous"}
+                    ]
+                },
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert result[0]["rejection_reason"] == "Dangerous"
+
+    def test_tool_calls_normalized_to_approval_with_tool_call_type(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "tool_calls": [
+                        {
+                            "id": "tc-1",
+                            "name": "list_pods",
+                            "input": {"ns": "default"},
+                            "execute": True,
+                        }
+                    ]
+                },
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 1
+        assert result[0]["type"] == "tool_call"
+        assert result[0]["name"] == "list_pods"
+        assert result[0]["id"] == "tc-1"
+        assert result[0]["input"] == {"ns": "default"}
+
+    def test_tool_calls_without_id_gets_generated_id(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {"tool_calls": [{"name": "foo", "input": {}, "execute": True}]},
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert result[0]["id"]  # non-empty
+
+    def test_tool_call_already_in_approvals_is_deduplicated(self):
+        """A tool_call whose id appears in data.approvals must not be processed twice."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "approvals": [
+                        {
+                            "id": "tc-1",
+                            "type": "tool_call",
+                            "name": "foo",
+                            "input": {},
+                            "execute": True,
+                        }
+                    ],
+                    "tool_calls": [{"id": "tc-1", "name": "foo", "input": {}, "execute": True}],
+                },
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 1  # not 2
+
+    def test_all_three_sources_merged(self):
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "approvals": [
+                        {
+                            "id": "a1",
+                            "type": "tool_call",
+                            "name": "foo",
+                            "input": {},
+                            "execute": True,
+                        }
+                    ],
+                    "cmds": [{"command": "ls", "execute": True}],
+                    "tool_calls": [{"id": "tc-2", "name": "bar", "input": {}, "execute": True}],
+                },
+            }
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 3
+
+    def test_reads_from_latest_message_only(self):
+        """Only the last message's data is used for current-turn approvals."""
+        adapter = _make_adapter()
+        messages = [
+            {
+                "role": "user",
+                "data": {
+                    "approvals": [
+                        {
+                            "id": "old",
+                            "type": "tool_call",
+                            "name": "old",
+                            "input": {},
+                            "execute": True,
+                        }
+                    ]
+                },
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "data": {
+                    "approvals": [
+                        {
+                            "id": "new",
+                            "type": "tool_call",
+                            "name": "new",
+                            "input": {},
+                            "execute": True,
+                        }
+                    ]
+                },
+            },
+        ]
+        result = adapter._normalize_approvals(messages)
+        assert len(result) == 1
+        assert result[0]["id"] == "new"
+
+
+# ---------------------------------------------------------------------------
+# _fan_out_executed
+# ---------------------------------------------------------------------------
+
+
+class TestFanOutExecuted:
+    def test_command_approval_produces_executed_command(self):
+        adapter = _make_adapter()
+        executed = [
+            ExecutedApproval(
+                id="x1",
+                type="command",
+                name="kubectl get pods",
+                input={"command": "kubectl get pods"},
+                output="pod1 Running",
+            )
+        ]
+        cmds, tool_calls = adapter._fan_out_executed(executed)
+        assert len(cmds) == 1
+        assert cmds[0].command == "kubectl get pods"
+        assert cmds[0].output == "pod1 Running"
+        assert len(tool_calls) == 0
+
+    def test_tool_call_approval_produces_executed_tool_call(self):
+        adapter = _make_adapter()
+        executed = [
+            ExecutedApproval(
+                id="tc-1",
+                type="tool_call",
+                name="list_pods",
+                input={"ns": "default"},
+                output="pod1",
+            )
+        ]
+        cmds, tool_calls = adapter._fan_out_executed(executed)
+        assert len(tool_calls) == 1
+        assert tool_calls[0].id == "tc-1"
+        assert tool_calls[0].name == "list_pods"
+        assert tool_calls[0].input == {"ns": "default"}
+        assert tool_calls[0].output == "pod1"
+        assert len(cmds) == 0
+
+    def test_mixed_approvals_split_correctly(self):
+        adapter = _make_adapter()
+        executed = [
+            ExecutedApproval(
+                id="x1", type="command", name="ls", input={"command": "ls -la"}, output="files"
+            ),
+            ExecutedApproval(id="tc-1", type="tool_call", name="foo", input={}, output="bar"),
+        ]
+        cmds, tool_calls = adapter._fan_out_executed(executed)
+        assert len(cmds) == 1
+        assert len(tool_calls) == 1
+
+    def test_empty_list_returns_empty_lists(self):
+        adapter = _make_adapter()
+        cmds, tool_calls = adapter._fan_out_executed([])
+        assert cmds == []
+        assert tool_calls == []
+
+    def test_command_uses_input_command_field(self):
+        """ExecutedCommand.command must be input['command'], not the approval name."""
+        adapter = _make_adapter()
+        executed = [
+            ExecutedApproval(
+                id="x1",
+                type="command",
+                name="run_shell_command",
+                input={"command": "kubectl get pods -n prod"},
+                output="ok",
+            )
+        ]
+        cmds, _ = adapter._fan_out_executed(executed)
+        assert cmds[0].command == "kubectl get pods -n prod"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: invoke_stream unified path
+# ---------------------------------------------------------------------------
+
+
+def _make_streaming_agent(tool_name: str, tool_result: str, llm_text: str):
+    mock_tool = MagicMock()
+    mock_tool.name = tool_name
+    mock_tool.execute = MagicMock(return_value=tool_result)
+
+    mock_agent = MagicMock()
+    mock_agent.tools = [mock_tool]
+
+    async def fake_stream(*args, **kwargs):
+        yield TextDeltaEvent(text=llm_text)
+        yield DoneEvent()
+
+    mock_agent.run_stream = MagicMock(side_effect=fake_stream)
+    return mock_agent, mock_tool
+
+
+class TestUnifiedPathInvokeStream:
+    async def test_legacy_cmds_execute_via_unified_path(self):
+        """data.cmds[] approval triggers execution and emits ExecutedApprovalsEvent."""
+        adapter = _make_adapter()
+        adapter._execute_cmd = MagicMock(return_value="pod1 Running")
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {"cmds": [{"command": "kubectl get pods", "execute": True}]},
+                }
+            ]
+        }
+
+        events = [e async for e in adapter.invoke_stream(messages)]
+        event_types = [e.type for e in events]
+
+        assert "executed_approvals" in event_types
+        exec_event = next(e for e in events if e.type == "executed_approvals")
+        assert exec_event.executed_approvals[0].type == "command"
+        assert exec_event.executed_approvals[0].output == "pod1 Running"
+
+    async def test_legacy_cmds_also_emit_executed_commands_event(self):
+        """data.cmds[] approval also emits legacy ExecutedCommandsEvent."""
+        adapter = _make_adapter()
+        adapter._execute_cmd = MagicMock(return_value="files listed")
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {"cmds": [{"command": "ls -la", "execute": True}]},
+                }
+            ]
+        }
+
+        events = [e async for e in adapter.invoke_stream(messages)]
+        event_types = [e.type for e in events]
+
+        assert "executed_commands" in event_types
+        ec_event = next(e for e in events if e.type == "executed_commands")
+        assert ec_event.executed_cmds[0].command == "ls -la"
+        assert ec_event.executed_cmds[0].output == "files listed"
+
+    async def test_legacy_tool_calls_execute_via_unified_path(self):
+        """data.tool_calls[] approval triggers execution and emits ExecutedApprovalsEvent."""
+        agent, tool = _make_agent_with_tool("list_pods", "pod1")
+        adapter = ServerAdapter(agent)
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {
+                        "tool_calls": [
+                            {"id": "tc-1", "name": "list_pods", "input": {}, "execute": True}
+                        ]
+                    },
+                }
+            ]
+        }
+
+        events = [e async for e in adapter.invoke_stream(messages)]
+        event_types = [e.type for e in events]
+
+        assert "executed_approvals" in event_types
+        tool.execute.assert_called_once()
+
+    async def test_legacy_tool_calls_also_emit_executed_tool_calls_event(self):
+        """data.tool_calls[] approval also emits legacy ExecutedToolCallsEvent."""
+        agent, tool = _make_agent_with_tool("list_pods", "pod1")
+        adapter = ServerAdapter(agent)
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {
+                        "tool_calls": [
+                            {"id": "tc-1", "name": "list_pods", "input": {}, "execute": True}
+                        ]
+                    },
+                }
+            ]
+        }
+
+        events = [e async for e in adapter.invoke_stream(messages)]
+        event_types = [e.type for e in events]
+
+        assert "executed_tool_calls" in event_types
+
+    async def test_mixed_approvals_and_cmds_all_execute(self):
+        """data.approvals + data.cmds in same message all get executed."""
+        adapter = _make_adapter()
+        adapter._execute_cmd = MagicMock(return_value="cmd output")
+
+        mock_tool = MagicMock()
+        mock_tool.name = "list_pods"
+        mock_tool.execute = MagicMock(return_value="pod output")
+        adapter.agent.tools = [mock_tool]
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {
+                        "approvals": [
+                            {
+                                "id": "a1",
+                                "type": "tool_call",
+                                "name": "list_pods",
+                                "input": {},
+                                "execute": True,
+                            }
+                        ],
+                        "cmds": [{"command": "ls", "execute": True}],
+                    },
+                }
+            ]
+        }
+
+        events = [e async for e in adapter.invoke_stream(messages)]
+        exec_event = next(e for e in events if e.type == "executed_approvals")
+        assert len(exec_event.executed_approvals) == 2
+
+
+class TestUnifiedPathInvoke:
+    async def test_legacy_cmds_included_in_response_data(self):
+        """invoke() response.data.executed_cmds populated from data.cmds[] approval."""
+        mock_response = MagicMock()
+        mock_response.needs_approval = False
+        mock_response.to_message.return_value = MagicMock(
+            content="done",
+            data=MagicMock(
+                executed_approvals=[],
+                executed_tool_calls=[],
+                executed_cmds=[],
+            ),
+        )
+        mock_agent = MagicMock()
+        mock_agent.tools = []
+        mock_agent.run = AsyncMock(return_value=mock_response)
+        adapter = ServerAdapter(mock_agent)
+        adapter._execute_cmd = MagicMock(return_value="ls output")
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {"cmds": [{"command": "ls", "execute": True}]},
+                }
+            ]
+        }
+
+        result = await adapter.invoke(messages)
+        assert len(result.data.executed_cmds) == 1
+        assert result.data.executed_cmds[0].command == "ls"
+
+    async def test_legacy_tool_calls_included_in_response_data(self):
+        """invoke() response.data.executed_tool_calls populated from data.tool_calls[]."""
+        mock_response = MagicMock()
+        mock_response.needs_approval = False
+        mock_response.to_message.return_value = MagicMock(
+            content="done",
+            data=MagicMock(
+                executed_approvals=[],
+                executed_tool_calls=[],
+                executed_cmds=[],
+            ),
+        )
+        agent, tool = _make_agent_with_tool("foo", "bar")
+        agent.run = AsyncMock(return_value=mock_response)
+        adapter = ServerAdapter(agent)
+
+        messages = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "data": {
+                        "tool_calls": [{"id": "tc-1", "name": "foo", "input": {}, "execute": True}]
+                    },
+                }
+            ]
+        }
+
+        result = await adapter.invoke(messages)
+        assert len(result.data.executed_tool_calls) == 1
+        assert result.data.executed_tool_calls[0].name == "foo"


### PR DESCRIPTION
## Summary

- Unifies three separate approval processing paths (`data.approvals[]`, `data.cmds[]`, `data.tool_calls[]`) into a single pipeline via `_normalize_approvals` → `_process_approvals` → `_fan_out_executed`
- Fixes `CommandsEvent` to carry the actual shell command string (not the tool function name) and include `files` from tool input
- Removes redundant `_process_approved_commands` and `_process_approved_tool_calls` methods

## Test plan

- [ ] Run `pytest tests/core/test_server_adapter.py tests/core/test_unified_approvals.py tests/core/test_cmd_flow.py tests/core/test_unified_processing.py -v` — all pass
- [ ] Run full suite `pytest` — all 751 tests pass, no regressions
- [ ] Verify `CommandsEvent.commands[].command` contains the shell command string, not the Python tool function name
- [ ] Verify mixed `data.approvals[]` + `data.cmds[]` in the same message all execute via unified path

🤖 Generated with [Claude Code](https://claude.com/claude-code)