### PR TITLE
feat(permissions): fix execution gap, enrich HTTP response, and add streaming parity

### DIFF
--- a/dcaf/core/adapters/outbound/agno/adapter.py
+++ b/dcaf/core/adapters/outbound/agno/adapter.py
@@ -929,10 +929,19 @@ class AgnoAdapter:
             # Note: Agno infers parameter schema from function signature automatically.
             # We only pass name and description - 'parameters' is NOT a valid Agno arg.
             # requires_confirmation tells Agno to pause before executing (HITL).
+            #
+            # When platform_context carries permission rules, ALL tools must pause so
+            # AgentService._process_response can gate execution via ApprovalPolicy
+            # (deny → reject, no-match → HITL, allow → execute via tool.execute()).
+            # Without this, Agno executes tools before the policy check runs.
+            has_permissions = bool(platform_context and platform_context.get("permissions"))
+            confirmation_required = (
+                True if has_permissions else (tool_obj.requires_approval or None)
+            )
             decorated_tool = agno_tool_decorator(
                 name=tool_schema["name"],
                 description=tool_schema["description"],
-                requires_confirmation=tool_obj.requires_approval or None,
+                requires_confirmation=confirmation_required,
             )(func_to_wrap)
 
             agno_tools.append(decorated_tool)

--- a/dcaf/core/agent.py
+++ b/dcaf/core/agent.py
@@ -77,6 +77,7 @@ from .models import ChatMessage, normalize_messages
 from .schemas.events import (
     DoneEvent,
     ErrorEvent,
+    ExecutedToolCallsEvent,
     IntermittentUpdateEvent,
     TextDeltaEvent,
     ToolCallsEvent,
@@ -199,6 +200,8 @@ class AgentResponse(LLMResponse):
 
     # Internal reference for continuing
     _agent: "Agent | None" = field(repr=False, default=None)
+    # Internal DTO from AgentService — carries rejected/executed tool calls for serialization
+    _internal_dto: Any = field(repr=False, default=None)
 
     def approve_all(self) -> "AgentResponse":
         """Approve all pending tool calls and continue execution."""
@@ -229,26 +232,51 @@ class AgentResponse(LLMResponse):
         """
         from dcaf.core.schemas.messages import AgentMessage, Data, ToolCall
 
-        # Build tool_calls for the Data container
-        tool_calls = []
-        for tc in self.pending_tools:
-            tool_calls.append(
+        # Prefer DTO data (has status, rejection_reason, executed_tool_calls) when available.
+        # Fall back to pending_tools for backwards compatibility.
+        dto = self._internal_dto
+        if dto is not None and hasattr(dto, "data"):
+            # Build ToolCall schema objects from DTO (includes status + rejection_reason)
+            tool_calls = []
+            for tc in getattr(dto.data, "tool_calls", []):
+                tool_calls.append(
+                    ToolCall(
+                        id=str(tc.id) if hasattr(tc, "id") else tc.get("id", ""),
+                        name=tc.name if hasattr(tc, "name") else tc.get("name", ""),
+                        input=tc.input if hasattr(tc, "input") else tc.get("input", {}),
+                        execute=getattr(tc, "execute", False),
+                        tool_description=getattr(tc, "tool_description", ""),
+                        input_description=getattr(tc, "input_description", {}),
+                        intent=getattr(tc, "intent", None),
+                        rejection_reason=getattr(tc, "rejection_reason", None),
+                        status=getattr(tc, "status", None),
+                        requires_approval=getattr(tc, "requires_approval", True),
+                    )
+                )
+            executed_tool_calls = list(getattr(dto.data, "executed_tool_calls", []))
+        else:
+            # Fallback: only pending tools are available
+            tool_calls = [
                 ToolCall(
                     id=tc.id,
                     name=tc.name,
                     input=tc.input,
-                    execute=False,  # Pending approval
+                    execute=False,
                     tool_description=tc.description or "",
                     input_description={},
+                    status="pending",
+                    requires_approval=True,
                 )
-            )
+                for tc in self.pending_tools
+            ]
+            executed_tool_calls = []
 
         # Build Data container with session
         data = Data(
             tool_calls=tool_calls,
             cmds=[],
             executed_cmds=[],
-            executed_tool_calls=[],
+            executed_tool_calls=executed_tool_calls,
             session=self.session,
         )
 
@@ -1089,7 +1117,8 @@ class Agent:
                     # Convert internal stream events to server stream events
                     server_event = self._convert_stream_event(event, pending_tool_calls)
                     if server_event and self._is_new_update(server_event, seen_update_texts):
-                        yield server_event
+                        async for out in self._gate_stream_event(server_event, platform_context):
+                            yield out
 
                 # Final drain after the runtime loop ends
                 while user_events:
@@ -1276,6 +1305,107 @@ class Agent:
 
         return None
 
+    async def _gate_stream_event(
+        self,
+        event: "ServerStreamEvent",
+        platform_context: "PlatformContext | None",
+    ) -> "AsyncIterator[ServerStreamEvent]":
+        """Yield events, applying the permission policy to ToolCallsEvents.
+
+        Extracted from run_stream to keep that method's branch count under the
+        PLR0912 threshold.
+        """
+        if (
+            isinstance(event, ToolCallsEvent)
+            and event.tool_calls
+            and platform_context
+            and platform_context.permissions
+        ):
+            for policy_event in self._apply_stream_policy(event, platform_context):
+                yield policy_event
+        else:
+            yield event
+
+    def _apply_stream_policy(
+        self,
+        event: "ToolCallsEvent",
+        platform_context: "PlatformContext",
+    ) -> "list[ServerStreamEvent]":
+        """Apply permission policy to streaming tool calls.
+
+        Called when Agno pauses (requires_confirmation=True) and emits a
+        TOOL_CALLS event.  Splits tool calls into three buckets:
+          - blocked  → TextDeltaEvent with rejection message
+          - HITL     → ToolCallsEvent (pending approval)
+          - allowed  → execute immediately, ExecutedToolCallsEvent
+
+        Returns a list of zero or more events to yield in place of the
+        original ToolCallsEvent.
+        """
+        from .schemas.messages import ExecutedToolCall as ExecSchema
+
+        policy = self._agent_service._policy
+
+        pending: list[SchemaToolCall] = []
+        executed: list[ExecSchema] = []
+        blocked_reasons: list[str] = []
+
+        for tc in event.tool_calls:
+            tool_obj = next((t for t in self.tools if t.name == tc.name), None)
+
+            class _FallbackTool:  # noqa: N801
+                name = tc.name
+                requires_approval = True
+
+            tool_for_policy = tool_obj or _FallbackTool()
+            decision = policy.check(tool_for_policy, platform_context, tc.input)
+
+            if decision.is_blocked:
+                blocked_reasons.append(decision.reason or "blocked by permission policy")
+
+            elif decision.requires_approval:
+                tc_with_status = SchemaToolCall(
+                    id=tc.id,
+                    name=tc.name,
+                    input=tc.input,
+                    execute=False,
+                    tool_description=getattr(tc, "tool_description", ""),
+                    input_description=getattr(tc, "input_description", {}),
+                    status="pending",
+                    requires_approval=True,
+                )
+                pending.append(tc_with_status)
+
+            else:
+                # Auto-execute
+                output = ""
+                if tool_obj:
+                    try:
+                        output = (
+                            tool_obj.execute(
+                                tc.input,
+                                platform_context.to_dict()
+                                if tool_obj.requires_platform_context
+                                else None,
+                            )
+                            or ""
+                        )
+                    except Exception as exc:
+                        output = f"Error: {exc}"
+                executed.append(ExecSchema(id=tc.id, name=tc.name, input=tc.input, output=output))
+
+        out: list[ServerStreamEvent] = []
+        if blocked_reasons:
+            reasons = "; ".join(blocked_reasons)
+            out.append(
+                TextDeltaEvent(text=f"The request was blocked by the permission policy: {reasons}")
+            )
+        if pending:
+            out.append(ToolCallsEvent(tool_calls=pending))
+        if executed:
+            out.append(ExecutedToolCallsEvent(executed_tool_calls=executed))
+        return out
+
     # Private methods
 
     def _convert_response(self, internal: Any, session: Session | None = None) -> AgentResponse:
@@ -1308,6 +1438,7 @@ class Agent:
             is_complete=getattr(internal, "is_complete", True),
             session=session_data,
             _agent=self,
+            _internal_dto=internal,
         )
 
     def _approve_all_and_continue(self, conversation_id: str) -> AgentResponse:

--- a/dcaf/core/application/services/agent_service.py
+++ b/dcaf/core/application/services/agent_service.py
@@ -14,7 +14,14 @@ from ...domain.value_objects import (
     ToolInput,
 )
 from ..dto.requests import AgentRequest
-from ..dto.responses import AgentResponse, DataDTO, StreamEvent, StreamEventType, ToolCallDTO
+from ..dto.responses import (
+    AgentResponse,
+    DataDTO,
+    ExecutedToolCallDTO,
+    StreamEvent,
+    StreamEventType,
+    ToolCallDTO,
+)
 from ..ports.agent_runtime import AgentRuntime
 from ..ports.conversation_repository import ConversationRepository
 from ..ports.event_publisher import EventPublisher
@@ -378,7 +385,8 @@ class AgentService:
             conversation.add_assistant_message(runtime_response.text)
 
         # Process tool calls
-        processed_tool_calls = []
+        processed_tool_calls: list[ToolCallDTO] = []
+        executed_tool_call_dtos: list[ExecutedToolCallDTO] = []
         for tc_dto in runtime_response.tool_calls:
             # Find the registered tool (may be None for runtime-only tools)
             tool = self._find_tool(tc_dto.name, tools)
@@ -424,12 +432,35 @@ class AgentService:
                         tool_call.start_execution()
                         tool_call.fail(str(e))
 
-                processed_tool_calls.append(ToolCallDTO.from_tool_call(tool_call))
+                # Auto-executed calls go to executed_tool_calls for wire-format clarity
+                executed_tool_call_dtos.append(
+                    ExecutedToolCallDTO(
+                        id=str(tool_call.id),
+                        name=tool_call.tool_name,
+                        input=tool_call.input.parameters,
+                        output=tool_call.result or tool_call.error or "",
+                    )
+                )
+
+        # Synthesize a rejection message when tools were blocked and there's no LLM text.
+        # This happens when Agno pauses before execution (requires_confirmation=True) and
+        # the policy hard-denies all tool calls, leaving text empty.
+        response_text = runtime_response.text
+        if not response_text:
+            blocked = [tc for tc in processed_tool_calls if tc.status == "rejected"]
+            if blocked:
+                reasons = "; ".join(
+                    tc.rejection_reason or "blocked by permission policy" for tc in blocked
+                )
+                response_text = f"The request was blocked by the permission policy: {reasons}"
 
         return AgentResponse(
             conversation_id=str(conversation.id),
-            text=runtime_response.text,
-            data=DataDTO(tool_calls=processed_tool_calls),
+            text=response_text,
+            data=DataDTO(
+                tool_calls=processed_tool_calls,
+                executed_tool_calls=executed_tool_call_dtos,
+            ),
             has_pending_approvals=conversation.has_pending_approvals,
             is_complete=not conversation.has_pending_approvals,
         )

--- a/dcaf/core/server.py
+++ b/dcaf/core/server.py
@@ -425,15 +425,32 @@ def create_app(
         try:
             result = await _invoke_agent(adapter, agent_input)
 
-            # Build response
+            # Build response — include full data + meta_data for permission/HITL clients
             response: dict[str, Any] = {
                 "role": result.role if hasattr(result, "role") else "assistant",
                 "content": result.content if hasattr(result, "content") else str(result),
             }
 
-            # Echo request_fields in meta_data.request_context if present
-            if request_fields:
+            # Include data (tool_calls, executed_tool_calls, etc.) when present
+            if hasattr(result, "data"):
+                data_dict = result.data.model_dump(exclude_none=True)
+                if any(data_dict.get(k) for k in ("tool_calls", "executed_tool_calls", "cmds")):
+                    response["data"] = data_dict
+
+            # Merge meta_data (has_pending_approvals, is_complete) into response
+            if hasattr(result, "meta_data") and result.meta_data:
+                meta = result.meta_data
+                if request_fields:
+                    meta = {**meta, "request_context": request_fields}
+                response["meta_data"] = meta
+            elif request_fields:
                 response["meta_data"] = {"request_context": request_fields}
+
+            # Promote key meta_data fields to top level for easy client access
+            if hasattr(result, "meta_data") and result.meta_data:
+                for key in ("has_pending_approvals", "is_complete"):
+                    if key in result.meta_data:
+                        response[key] = result.meta_data[key]
 
             return response
 

--- a/dcaf/schemas/messages.py
+++ b/dcaf/schemas/messages.py
@@ -31,6 +31,8 @@ class ToolCall(BaseModel):
     input_description: dict[str, Any]
     intent: str | None = None
     rejection_reason: str | None = None
+    status: str | None = None
+    requires_approval: bool = True
 
 
 class ExecutedToolCall(BaseModel):

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -3,10 +3,13 @@
 DCAF's permission engine evaluates every tool call against a layered deny/allow
 rule chain before executing it or sending it to Human-in-the-Loop (HITL).
 
+---
+
 ## Evaluation Chain
 
 Rules are evaluated top-down. **First match wins.** The entire deny chain runs
-before the allow chain begins.
+before the allow chain begins — so any deny rule at any layer beats any allow
+rule at any layer.
 
 | Step | Layer   | List  | Managed By     | Match Result |
 |------|---------|-------|----------------|--------------|
@@ -22,7 +25,15 @@ before the allow chain begins.
 | 10   | Ticket  | ALLOW | End User       | → ALLOWED    |
 | 11   | —       | —     | —              | → HITL       |
 
-A higher-layer DENY cannot be bypassed by a lower-layer ALLOW.
+**Key rules:**
+
+- A global DENY (step 1) cannot be overridden by any allow at any layer.
+- An agent-level DENY (step 3) beats a global ALLOW (step 6) — deny chain
+  always runs first.
+- Ticket-level ALLOW (step 10) is for one-off grants on commands that have no
+  deny match but would otherwise go to HITL (step 11). It cannot bypass a deny.
+
+---
 
 ## Rule Syntax
 
@@ -30,80 +41,259 @@ A higher-layer DENY cannot be bypassed by a lower-layer ALLOW.
 ToolName(argument glob pattern)
 ```
 
-- **Tool name** is matched case-insensitively.
-- **Argument pattern** uses standard glob syntax (`*`, `?`).
-- Rules with no parentheses match any call to that tool regardless of arguments.
+- **Tool name** is matched **case-insensitively** (`bash` matches `Bash`).
+- **Argument pattern** uses standard glob syntax (`*` matches any sequence,
+  `?` matches any single character).
+- Rules with **no parentheses** match any call to that tool regardless of
+  arguments.
 
 Examples:
 
 ```
-Bash(kubectl delete *)          # blocks all kubectl delete commands
-Bash(kubectl get *)             # allows all kubectl get commands
-Bash(* --version)               # allows --version on any tool
-kubectl                         # matches any kubectl call
+Bash(kubectl delete *)           # blocks all kubectl delete commands
+Bash(kubectl get *)              # allows all kubectl get commands
+Bash(kubectl scale * --replicas=3)  # specific scale command
+bash(kubectl get *)              # lowercase tool name also matches 'Bash'
+Bash                             # matches ANY Bash call (no arg filter)
 ```
+
+### How the argument is extracted
+
+The rule pattern is matched against a **single string** derived from the tool's
+input:
+
+| Tool input                          | Matched string                  |
+|-------------------------------------|---------------------------------|
+| `{"command": "kubectl get pods"}`   | `kubectl get pods`              |
+| `"kubectl get pods"` (plain string) | `kubectl get pods`              |
+| `{"cmd": "ls", "dir": "/tmp"}`      | `ls /tmp` (all values joined)   |
+| `{}`  or `null`                     | `None` — bare tool-name rules still match |
+
+Single-key dicts (the common case for shell tools) use just the value. Multi-key
+dicts concatenate all values with spaces. This means argument patterns always
+work naturally for tools like `Bash(command=...)`.
+
+### Rule matching within a layer
+
+Each layer can have multiple rules. They are evaluated in order; the **first
+matching rule in that layer** triggers the decision for the whole layer.
+Because the outer loop iterates layers in the fixed order
+`global → project → agent → skill → ticket`, the effective precedence is:
+
+1. Global deny rules (checked left-to-right within the layer)
+2. Project deny rules
+3. Agent deny rules
+4. Skill deny rules
+5. Ticket deny rules
+6. Global allow rules
+7. Project allow rules
+8. Agent allow rules
+9. Skill allow rules
+10. Ticket allow rules
+
+---
 
 ## Wire Format
 
-Permissions arrive in `platform_context.permissions` as a list of layer objects:
+Permissions arrive in `platform_context.permissions` inside the last user
+message:
 
 ```json
 {
-  "permissions": [
-    {
-      "layer": "global",
-      "list": "deny",
-      "rules": [
-        "Bash(kubectl delete *)",
-        "Bash(kubectl exec *)"
-      ]
-    },
-    {
-      "layer": "global",
-      "list": "allow",
-      "rules": [
-        "Bash(kubectl get *)",
-        "Bash(kubectl describe *)"
+  "messages": [{
+    "role": "user",
+    "content": "List my pods",
+    "platform_context": {
+      "permissions": [
+        {
+          "layer": "global",
+          "list": "deny",
+          "rules": [
+            "Bash(kubectl delete *)",
+            "Bash(kubectl exec *)"
+          ]
+        },
+        {
+          "layer": "global",
+          "list": "allow",
+          "rules": [
+            "Bash(kubectl get *)",
+            "Bash(kubectl describe *)"
+          ]
+        },
+        {
+          "layer": "ticket",
+          "list": "allow",
+          "rules": [
+            "Bash(kubectl scale deployment/worker --replicas=3)"
+          ]
+        }
       ]
     }
-  ]
+  }]
 }
 ```
 
+**Notes:**
+
+- `layer` must be one of: `global`, `project`, `agent`, `skill`, `ticket`.
+- `list` must be `deny` or `allow`.
+- An empty `rules` array is a **no-op** — that layer is simply skipped.
+- Omitting a layer entirely is equivalent to an empty rules array for that layer.
+- Multiple entries for the same `layer`/`list` pair are supported; all rules
+  from all matching entries are evaluated in the order they appear.
+
+---
+
 ## Step-by-Step Example
 
-**Action requested:** `Bash(kubectl get pods)`
+**Permissions configured:**
+
+| Layer  | List  | Rules                                    |
+|--------|-------|------------------------------------------|
+| global | deny  | `Bash(kubectl delete *)`, `Bash(kubectl exec *)` |
+| global | allow | `Bash(kubectl get *)`, `Bash(kubectl describe *)` |
+| ticket | allow | `Bash(kubectl scale deployment/worker --replicas=3)` |
+
+---
+
+### Case 1 — `kubectl get pods` → ALLOWED
 
 ```
-Step 1 — Global DENY:   "Bash(kubectl delete *)"      → no match, continue
-Step 2 — Project DENY:  "Bash(kubectl exec *)"        → no match, continue
-Step 3 — Agent DENY:    "Bash(kubectl apply *)"       → no match, continue
-Step 4 — Skill DENY:    "Bash(kubectl drain *)"       → no match, continue
-Step 5 — Ticket DENY:   (no ticket-level deny rules)  → no match, continue
+Step 1  Global DENY:   "Bash(kubectl delete *)"      → no match
+                       "Bash(kubectl exec *)"         → no match
+Step 2  Project DENY:  (no rules)                    → no match
+Step 3  Agent DENY:    (no rules)                    → no match
+Step 4  Skill DENY:    (no rules)                    → no match
+Step 5  Ticket DENY:   (no rules)                    → no match
 
-Step 6 — Global ALLOW:  "Bash(kubectl get *)"         → ✅ MATCH → ALLOWED
+Step 6  Global ALLOW:  "Bash(kubectl get *)"          → ✅ MATCH → ALLOWED
 ```
+
+---
+
+### Case 2 — `kubectl delete pods --all` → BLOCKED
+
+```
+Step 1  Global DENY:   "Bash(kubectl delete *)"       → ✅ MATCH → BLOCKED
+        rejection_reason: "Blocked by global deny rule: Bash(kubectl delete *)"
+```
+
+The response includes:
+```json
+{
+  "content": "The request was blocked by the permission policy: Blocked by global deny rule: Bash(kubectl delete *)",
+  "data": {
+    "tool_calls": [{
+      "name": "Bash",
+      "input": {"command": "kubectl delete pods --all"},
+      "status": "rejected",
+      "rejection_reason": "Blocked by global deny rule: Bash(kubectl delete *)"
+    }]
+  },
+  "has_pending_approvals": false,
+  "is_complete": true
+}
+```
+
+---
+
+### Case 3 — `helm upgrade my-release ./chart` → HITL
+
+```
+Steps 1-5  DENY chain:   no rules match "helm upgrade ..."
+Steps 6-10 ALLOW chain:  no rules match "helm upgrade ..."
+
+Step 11  No match → HITL (pending approval)
+```
+
+The response includes:
+```json
+{
+  "data": {
+    "tool_calls": [{
+      "name": "Bash",
+      "status": "pending",
+      "requires_approval": true
+    }]
+  },
+  "has_pending_approvals": true,
+  "is_complete": false
+}
+```
+
+---
+
+### Case 4 — `kubectl scale deployment/worker --replicas=3` → ALLOWED via ticket
+
+```
+Steps 1-5  DENY chain:   no rules match
+Step 6     Global ALLOW: "Bash(kubectl get *)"         → no match (wrong command)
+Steps 7-9  ALLOW chain:  (no project/agent/skill rules)
+Step 10    Ticket ALLOW: "Bash(kubectl scale deployment/worker --replicas=3)"
+                                                        → ✅ MATCH → ALLOWED
+```
+
+---
 
 ## Human-in-the-Loop Fallback
 
 When no rule matches across all 10 steps (step 11), DCAF sends the tool call
 to the end user for approval. The user can:
 
-- **Approve once** — the action executes this time only.
-- **Deny once** — the action is blocked this time only.
+- **Approve** — the action executes this turn only.
+- **Deny** — the action is blocked this turn only.
+
+The pending tool call appears in `data.tool_calls` with `status: "pending"` and
+`requires_approval: true`. To approve, re-submit the conversation with that tool
+call's `execute` field set to `true`:
+
+```json
+{
+  "data": {
+    "tool_calls": [{"id": "tc-1", "name": "Bash", "input": {...}, "execute": true}]
+  }
+}
+```
+
+---
+
+## Streaming Endpoint Parity
+
+The streaming endpoint (`POST /api/chat-stream`) applies the **same** permission
+policy:
+
+- **Blocked** tool call → `text_delta` event with rejection message; no
+  `tool_calls` event is emitted.
+- **HITL** tool call → `tool_calls` event with `status: "pending"` and
+  `requires_approval: true`.
+- **Allowed** tool call → `executed_tool_calls` event with the result.
+
+---
 
 ## Fallback Behaviour
 
-When `permissions` is absent or empty, DCAF falls back to the tool-level
-`requires_approval=True` flag on each `@tool` definition (existing behaviour,
-fully backwards compatible).
+When `permissions` is absent or `[]`, DCAF falls back to the tool-level
+`requires_approval` flag on each `@tool` definition (existing pre-permissions
+behaviour, fully backwards compatible).
+
+```python
+@tool(description="Run a shell command", requires_approval=True)
+def Bash(command: str) -> str: ...
+```
+
+With no permissions in context, this tool always goes to HITL. With permissions
+present, the permission chain governs instead — an allow rule can execute it
+without HITL even if `requires_approval=True` is set on the tool definition.
+
+---
 
 ## Layer Ownership
 
-| Layer   | Who Sets It    | Scope                        |
-|---------|----------------|------------------------------|
-| Global  | Helpdesk Admin | All projects & agents        |
-| Project | Project Admin  | All agents in the project    |
-| Agent   | Platform       | That agent only              |
-| Skill   | Platform       | Agents with that skill       |
-| Ticket  | System via HITL| Single ticket lifecycle      |
+| Layer   | Who Sets It      | Scope                        |
+|---------|------------------|------------------------------|
+| Global  | Helpdesk Admin   | All projects & agents        |
+| Project | Project Admin    | All agents in the project    |
+| Agent   | Platform         | That agent only              |
+| Skill   | Platform         | Agents with that skill       |
+| Ticket  | System via HITL  | Single ticket lifecycle      |


### PR DESCRIPTION
## Summary

- **Execution gap fix**: forced `requires_confirmation=True` in the Agno adapter whenever permissions are present, ensuring every tool call passes through `ApprovalPolicy` before execution rather than running unconditionally
- **Rich HTTP response**: `_handle_chat_v2` now returns `data` (with `tool_calls`/`executed_tool_calls`), `meta_data`, `has_pending_approvals`, and `is_complete` so callers can inspect rejected/pending/executed status per tool call
- **Streaming parity**: `run_stream` now applies the same permission policy via `_gate_stream_event`/`_apply_stream_policy`, matching the sync endpoint behaviour for block, HITL, and allow cases
- **Schema additions**: `ToolCall` gains `status` and `requires_approval` fields so the HTTP response surface is consistent with the streaming surface
- **Rejection message**: when all tool calls are blocked and the LLM emitted no text, `agent_service` synthesizes a human-readable rejection message
- **Docs**: `docs/guides/permissions.md` expanded to a full reference — argument extraction rules, step-by-step examples, exact response shapes, streaming parity and fallback behaviour

## Test Plan

- [ ] All 16 test cases in `docs/review/permissions-chat-endpoint-test-plan.md` verified against `POST /api/chat`
- [ ] Tests 1 (deny) and 3 (HITL) verified against `POST /api/chat-stream`
- [ ] 744 unit tests pass (`pytest -q`)
- [ ] Lint clean (`ruff check .` + `ruff format --check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)